### PR TITLE
A couple of tweaks to pod_server

### DIFF
--- a/pod-server/Cargo.toml
+++ b/pod-server/Cargo.toml
@@ -16,7 +16,7 @@ rust-sgx-util = { path = "crates/rust-sgx-util", features = ["serde"], version =
 anyhow = "1"
 serde = "1"
 log = "0.4"
-env_logger = "0.6"
+pretty_env_logger = "0.4"
 structopt = "0.3"
 toml = "0.5"
 

--- a/pod-server/Cargo.toml
+++ b/pod-server/Cargo.toml
@@ -18,7 +18,7 @@ serde = "1"
 log = "0.4"
 env_logger = "0.6"
 structopt = "0.3"
-futures = "0.3"
+toml = "0.5"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/pod-server/crates/rust-sgx-util/src/ias.rs
+++ b/pod-server/crates/rust-sgx-util/src/ias.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 use std::ffi::CString;
 use std::ops::Deref;
 use std::path::Path;
+use std::ptr::{self, NonNull};
 use std::str::FromStr;
-use std::{fmt, ptr, slice, u32};
-use std::sync::atomic::{Ordering, AtomicPtr};
+use std::{fmt, slice, u32};
 
 const IAS_VERIFY_URL: &str = "https://api.trustedservices.intel.com/sgx/dev/attestation/v3/report";
 const IAS_SIGRL_URL: &str = "https://api.trustedservices.intel.com/sgx/dev/attestation/v3/sigrl";
@@ -24,7 +24,7 @@ pub struct IasHandle {
     verify_url: CString,
     #[allow(dead_code)]
     sigrl_url: CString,
-    context: Option<AtomicPtr<c::IasContext>>,
+    context: NonNull<c::IasContext>,
 }
 
 impl IasHandle {
@@ -65,10 +65,7 @@ impl IasHandle {
         let sigrl_url = CString::new(sigrl_url)?;
         let raw_context =
             unsafe { c::ias_init(api_key.as_ptr(), verify_url.as_ptr(), sigrl_url.as_ptr()) };
-        if raw_context == ptr::null_mut() {
-            return Err(Error::IasInitNullPtr);
-        }
-        let context = Some(AtomicPtr::new(raw_context));
+        let context = NonNull::new(raw_context).ok_or(Error::IasInitNullPtr)?;
         Ok(Self {
             verify_url,
             sigrl_url,
@@ -104,7 +101,7 @@ impl IasHandle {
         let mut raw = ptr::null_mut();
         let ret = unsafe {
             c::ias_get_sigrl(
-                self.context.as_ref().unwrap().load(Ordering::SeqCst),
+                self.context.as_ptr(),
                 group_id.as_ptr(),
                 &mut size,
                 &mut raw,
@@ -177,7 +174,7 @@ impl IasHandle {
         };
         let ret = unsafe {
             c::ias_verify_quote(
-                self.context.as_ref().unwrap().load(Ordering::SeqCst),
+                self.context.as_ptr(),
                 quote.as_ptr() as *const _,
                 quote.len(),
                 nonce.as_ptr(),
@@ -197,8 +194,7 @@ impl IasHandle {
 
 impl Drop for IasHandle {
     fn drop(&mut self) {
-        let raw = self.context.take();
-        unsafe { c::ias_cleanup(raw.unwrap().into_inner()) }
+        unsafe { c::ias_cleanup(self.context.as_ptr()) }
     }
 }
 


### PR DESCRIPTION
So, the main change here is that, thanks to the use of `env::var`, we can get away with creating
one `IasHandle` instance per worker thread which as a result implies we don't need to make the inner `c::IasContext` pointer atomic (cleans up the inner interface a lot since we can now do `Drop` without `Option` shenanigans).

Also, now the server is configured from a TOML config file, and we properly propagate verbose request all the way to the `sgx_util` C-lib.