### PR TITLE
Re-enable remote attestation at the server

### DIFF
--- a/pod-server/Cargo.toml
+++ b/pod-server/Cargo.toml
@@ -14,7 +14,7 @@ actix-web = "2"
 actix-rt = "1"
 actix-session = "0.3"
 actix-identity = "0.2"
-rust-sgx-util = { path = "crates/rust-sgx-util", features = ["with_serde"], version = "0.2.1" }
+rust-sgx-util = { path = "crates/rust-sgx-util", features = ["with_serde"], version = "0.2.2" }
 anyhow = "1"
 thiserror = "1"
 serde = "1"

--- a/pod-server/Cargo.toml
+++ b/pod-server/Cargo.toml
@@ -29,7 +29,6 @@ tokio-diesel = "0.3"
 dotenv = "0.9"
 futures = "0.3" 
 getrandom = "0.1"
-rand = "0.7"
 base64 = "0.12"
 ed25519-dalek = "1.0.0-pre.3"
 

--- a/pod-server/crates/rust-sgx-util/Cargo.toml
+++ b/pod-server/crates/rust-sgx-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-sgx-util"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 license = "LGPL-3.0"

--- a/pod-server/src/entrypoints.rs
+++ b/pod-server/src/entrypoints.rs
@@ -25,7 +25,7 @@ fn verify_quote(quote: &Quote, nonce: Option<&Nonce>) -> Result<(), AppError> {
     // Verify the provided data with IAS.
     let api_key = env::var("POD_SERVER_API_KEY")?;
     let handle = IasHandle::new(&api_key, None, None)?;
-    // handle.verify_quote(quote, nonce, None, None, None, None)?;
+    handle.verify_quote(quote, nonce, None, None, None, None)?;
     Ok(())
 }
 


### PR DESCRIPTION
Since I've managed to successfully install @omeg's `pod_client` lib,
and generate a valid quote, the IAS attestation now works fine within
the web service, so I'm gonna go ahead and re-enable it then.

Also, while exploring this, I've found a small bug with `rust-sgx-util`
in the way we were calling `ias_verify_quote` C-fn, and I've fixed it
now.

It is now possible to send the `pod_client` generated quote using
the `test_client` to the server and properly register the user.
However, the authentication bit is currently not functional since I
still need to hook up `pod_client` lib into the `test_client` to
be able to spin up the enclave and sign the challenge.

cc @mdtanrikulu as an FYI