### PR TITLE
Hook up `libpod_sgx` with `test_client`

### DIFF
--- a/pod-server/Cargo.toml
+++ b/pod-server/Cargo.toml
@@ -32,6 +32,9 @@ getrandom = "0.1"
 base64 = "0.12"
 ed25519-dalek = "1.0.0-pre.3"
 
+[dev-dependencies]
+libc = "0.2"
+
 [badges]
 maintenance = { status = "actively-developed" }
 


### PR DESCRIPTION
This PR hooks up `libpod_sgx.so` with the `test_client` which now allows us to perform full end-to-end tests using the `test_client`. One caveat though, this is still pretty hacky, but works! :-D