### PR TITLE
Refactor Quote and Nonce in rust-sgx-util lib

### DIFF
--- a/pod-server/Cargo.toml
+++ b/pod-server/Cargo.toml
@@ -14,7 +14,7 @@ actix-web = "2"
 actix-rt = "1"
 actix-session = "0.3"
 actix-identity = "0.2"
-rust-sgx-util = { path = "crates/rust-sgx-util", features = ["with_serde"], version = "0.2.2" }
+rust-sgx-util = { path = "crates/rust-sgx-util", features = ["with_serde"], version = "0.2.3" }
 anyhow = "1"
 thiserror = "1"
 serde = "1"

--- a/pod-server/crates/rust-sgx-util/Cargo.toml
+++ b/pod-server/crates/rust-sgx-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-sgx-util"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 license = "LGPL-3.0"

--- a/pod-server/crates/rust-sgx-util/src/lib.rs
+++ b/pod-server/crates/rust-sgx-util/src/lib.rs
@@ -5,20 +5,20 @@
 //! ```toml
 //! rust-sgx-util = "0.2"
 //! ```
-//! 
+//!
 //! For `serde` support, you can enable it with `with_serde` feature:
-//! 
+//!
 //! ```toml
 //! rust-sgx-util = { version = "0.2", features = ["with_serde"] }
 //! ```
-//! 
+//!
 //! ## Prerequisites
-//! 
+//!
 //! Currently, this crate requires you compile and install `sgx_util` as
 //! a shared library.
-//! 
+//!
 //! ## Usage examples
-//! 
+//!
 //! You can find usage examples in the `examples` dir of the crate.
 //!
 mod c;
@@ -41,6 +41,9 @@ pub enum Error {
     /// Failed to initialize `IasHandle`.
     #[error("failed to initialize IasHandle")]
     IasInitNullPtr,
+    /// `Quote`'s size is too small.
+    #[error("quote's size is too small")]
+    QuoteTooShort,
     /// `IasHandle::get_sigrl` returned nonzero return code.
     #[error("get_sigrl returned nonzero return code: {}", _0)]
     IasGetSigrlNonZero(i32),
@@ -79,9 +82,44 @@ pub fn set_verbose(verbose: bool) {
 #[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
 pub struct Quote(#[cfg_attr(feature = "with_serde", serde(with = "ser_de"))] Vec<u8>);
 
+impl Quote {
+    const REPORT_BEGIN: usize = 368;
+    const REPORT_END: usize = 432;
+
+    /// Returns `report_data` bytes embedded within this `Quote`.
+    ///
+    /// The size of the returned slice is 64 bytes.
+    ///
+    /// # Errors
+    ///
+    /// This function will fail with [`Error::QuoteTooShort`] if `Quote`
+    /// is shorter than `432` bytes. Note that this is only a quick check
+    /// that we can extract the region in `Quote`'s buffer where we expect
+    /// the `report_data` to lie in. We don't do any validations on the
+    /// `Quote` in this method.
+    ///
+    /// [`Error::QuoteTooShort`]: enum.Error.html#variant.QuoteTooShort
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use rust_sgx_util::Quote;
+    /// let quote = Quote::from(&[0u8; 438][..]);
+    /// assert_eq!(quote.report_data().unwrap().len(), 64);
+    ///
+    /// let quote = Quote::from(&[0u8; 10][..]);
+    /// assert!(quote.report_data().is_err());
+    /// ```
+    pub fn report_data(&self) -> Result<&[u8]> {
+        self.0
+            .get(Self::REPORT_BEGIN..Self::REPORT_END)
+            .ok_or(Error::QuoteTooShort)
+    }
+}
+
 impl From<&[u8]> for Quote {
     fn from(bytes: &[u8]) -> Self {
-        Self(bytes.to_vec())
+        Self::from(bytes.to_vec())
     }
 }
 
@@ -106,7 +144,7 @@ impl Deref for Quote {
 ///
 /// `Nonce` implements `Deref<Target=[u8]>`, therefore dereferencing it will
 /// yield its inner buffer of bytes.
-/// 
+///
 /// # Serializing/deserializing
 ///
 /// With `with_serde` feature enabled, `Nonce` can be serialized and deserialized

--- a/pod-server/examples/test_client.rs
+++ b/pod-server/examples/test_client.rs
@@ -5,7 +5,7 @@ use rust_sgx_util::{Nonce, Quote};
 use serde::Serialize;
 use std::ffi::CString;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use structopt::StructOpt;
 
 #[link(name = "pod_sgx")]


### PR DESCRIPTION
This PR adds a fallible method for extracting `report_data` from
`Quote`. If the `Quote` was created from a too short a buffer, then
`fn report_data` will return `Error::QuoteTooShort`.

It also makes conversion from `&[u8]` into `Nonce` fallible.