### PR TITLE
Some pod_server cleanup

### DIFF
--- a/pod-server/Cargo.toml
+++ b/pod-server/Cargo.toml
@@ -23,11 +23,9 @@ log = "0.4"
 pretty_env_logger = "0.4"
 structopt = "0.3"
 toml = "0.5"
-tokio = { version = "0.2", features = ["blocking", "time", "rt-core"] }
 diesel = { version = "1.0", features = ["sqlite"] }
 tokio-diesel = "0.3"
 dotenv = "0.9"
-futures = "0.3" 
 getrandom = "0.1"
 base64 = "0.12"
 ed25519-dalek = "1.0.0-pre.3"

--- a/pod-server/README.md
+++ b/pod-server/README.md
@@ -56,21 +56,23 @@ cargo run -- config.toml -v
 
 ### RESTful API
 
-The service strives to communicate with JSON only, hence, if there is an error,
-its description will be communication inside the message's body encoded as JSON.
-
-Example response content:
+The service strives to communicate with JSON only, and the message will have a 
+general structure like below:
 
 ```json
 {
-  "description": "Something went wrong!"
+  "status": "ok",
+  "description": "some message"
 }
 ```
 
+`status` assumes either `ok`, or `error`, and details are encapsulated within
+the `description` field.
+
 #### Available entrypoints:
 
-* GET `/` -- dummy route which will respond with a JSON indicating whether the user
-  is authenticated or not.
+* GET `/` -- dummy route which will respond with `203` if user successfully
+  authenticated, or a `403` with description of the error encoded as JSON.
 
 
 * POST `/register` -- route required to register a new user with the service. The
@@ -89,8 +91,7 @@ Example response content:
 
   Nonce is optional, however both quote and nonce should be base64 encoded.
 
-  Upon successful registration, a `200` message will be generated with empty
-  body.
+  Upon successful registration, a `200` message will be generated.
 
 * GET `/auth` -- route required to initiate challenge-response protocol in order
   to authenticate the registered user using their SGX enclave (which holds a
@@ -102,6 +103,8 @@ Example response content:
 
   ```json
   {
+    "status": "ok",
+    "description": "challenge successfully generated",
     "challenge": "AAAA...AAA"
   }
   ```

--- a/pod-server/src/error.rs
+++ b/pod-server/src/error.rs
@@ -27,8 +27,8 @@ pub enum AppError {
     DieselResult(#[from] diesel::result::Error),
     #[error("var not found in env {:?}", _0)]
     Var(#[from] std::env::VarError),
-    #[error("spawning task failed with error: {:?}", _0)]
-    TokioJoin(#[from] tokio::task::JoinError),
+    #[error("blocking operation was canceled prematurely")]
+    ActixBlockingCanceled,
     #[error("decoding base64 to blob: {:?}", _0)]
     Base64Decode(#[from] base64::DecodeError),
     #[error("parsing ed25519 signature: {:?}", _0)]
@@ -52,7 +52,7 @@ impl ResponseError for AppError {
             AppError::R2d2Pool(_) => StatusCode::INTERNAL_SERVER_ERROR,
             AppError::DieselResult(_) => StatusCode::INTERNAL_SERVER_ERROR,
             AppError::Var(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            AppError::TokioJoin(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            AppError::ActixBlockingCanceled => StatusCode::INTERNAL_SERVER_ERROR,
             AppError::Base64Decode(_) => StatusCode::INTERNAL_SERVER_ERROR,
             AppError::Ed25519Signature(_) => StatusCode::BAD_REQUEST,
             AppError::GetRandom(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/pod-server/src/handlers/auth.rs
+++ b/pod-server/src/handlers/auth.rs
@@ -1,90 +1,17 @@
-use super::AppData;
-use crate::error::AppError;
-use crate::models::{NewUser, User};
+use super::AppError;
+use crate::models::User;
+use crate::AppData;
 
 use diesel::prelude::*;
 
 use actix_identity::Identity;
 use actix_session::Session;
-use actix_web::error::BlockingError;
 use actix_web::{web, HttpResponse, Responder};
-use rust_sgx_util::{IasHandle, Nonce, Quote};
 use serde::Deserialize;
 use serde_json::json;
-use std::env;
 use tokio_diesel::{AsyncRunQueryDsl, OptionalExtension};
 
-#[derive(Debug, Deserialize)]
-pub struct RegisterInfo {
-    login: String,
-    quote: Quote,
-    nonce: Option<Nonce>,
-}
-
-pub async fn register(
-    info: web::Json<RegisterInfo>,
-    app_data: web::Data<AppData>,
-) -> impl Responder {
-    use crate::schema::users::dsl::*;
-
-    log::info!(
-        "Received register request for user with login '{}'.",
-        info.login
-    );
-    log::debug!("Received data: {:?}", info);
-
-    // Check if the user is already registered.
-    let result = users
-        .filter(login.eq(info.login.clone()))
-        .get_result_async::<User>(&app_data.pool)
-        .await
-        .optional()?;
-    log::debug!("Matching user records found: {:?}", result);
-
-    if let Some(_) = result {
-        log::info!("User already registered.");
-        return Err(AppError::AlreadyRegistered);
-    }
-
-    let quote = info.quote.clone();
-    let nonce = info.nonce.clone();
-    if let Err(err) = web::block(move || {
-        // Verify the provided data with IAS.
-        let api_key = env::var("POD_SERVER_API_KEY")?;
-        let handle = IasHandle::new(&api_key, None, None)?;
-        handle.verify_quote(&quote, nonce.as_ref(), None, None, None, None)?;
-        Ok(())
-    })
-    .await
-    {
-        match err {
-            BlockingError::Error(err) => return Err(err),
-            BlockingError::Canceled => return Err(AppError::ActixBlockingCanceled),
-        }
-    };
-
-    // Extract pub_key from Quote
-    // ED25519 public key is 32 bytes long
-    let report_data = info.quote.report_data()?;
-    let pub_key_ = base64::encode(&report_data[..32]);
-    log::debug!("Extracted public key (base64 encoded): {:?}", pub_key_);
-
-    // Insert user to the database.
-    let new_user = NewUser {
-        login: info.login.clone(),
-        pub_key: pub_key_,
-    };
-    diesel::insert_into(users)
-        .values(new_user)
-        .execute_async(&app_data.pool)
-        .await?;
-
-    log::info!("User '{}' successfully inserted into db.", info.login);
-
-    Ok(HttpResponse::Ok())
-}
-
-pub async fn get_auth(session: Session, identity: Identity) -> impl Responder {
+pub async fn get(session: Session, identity: Identity) -> impl Responder {
     if let Some(id) = identity.identity() {
         log::info!("User '{}' already authenticated!", id);
         return Err(AppError::AlreadyAuthenticated);
@@ -120,7 +47,7 @@ pub struct AuthChallengeResponse {
     response: String, // base64 encoded
 }
 
-pub async fn auth(
+pub async fn post(
     response: web::Json<AuthChallengeResponse>,
     app_data: web::Data<AppData>,
     session: Session,
@@ -166,11 +93,4 @@ pub async fn auth(
     session.purge();
 
     Ok(HttpResponse::Ok())
-}
-
-pub async fn index(identity: Identity) -> impl Responder {
-    match identity.identity() {
-        Some(_) => Ok(HttpResponse::Ok().json(json!({"description": "You are authenticated!"}))),
-        None => Err(AppError::NotAuthenticated),
-    }
 }

--- a/pod-server/src/handlers/mod.rs
+++ b/pod-server/src/handlers/mod.rs
@@ -5,70 +5,106 @@ use actix_identity::Identity;
 use actix_web::dev::HttpResponseBuilder;
 use actix_web::http::StatusCode;
 use actix_web::{HttpResponse, Responder, ResponseError};
-use serde_json::json;
+use serde::Serialize;
+use std::collections::HashMap;
 
 pub async fn index(identity: Identity) -> impl Responder {
     match identity.identity() {
-        Some(_) => Ok(HttpResponse::Ok().json(json!({"description": "You are authenticated!"}))),
+        Some(_) => Ok(HttpResponse::NoContent()),
         None => Err(AppError::NotAuthenticated),
     }
 }
 
+#[derive(Serialize)]
+enum Status {
+    Ok,
+    Error,
+}
+
+#[derive(Serialize)]
+struct Message {
+    status: Status,
+    #[serde(flatten)]
+    params: HashMap<String, String>,
+}
+
+impl Message {
+    fn ok() -> Self {
+        Self {
+            status: Status::Ok,
+            params: HashMap::new(),
+        }
+    }
+
+    fn error() -> Self {
+        Self {
+            status: Status::Error,
+            params: HashMap::new(),
+        }
+    }
+
+    fn add_param<S1: AsRef<str>, S2: AsRef<str>>(mut self, key: S1, value: S2) -> Self {
+        self.params
+            .insert(key.as_ref().to_owned(), value.as_ref().to_owned());
+        self
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
-pub enum AppError {
-    #[error("User already registered")]
-    AlreadyRegistered,
-    #[error("User not registered yet")]
+enum AppError {
+    #[error("user not registered yet")]
     NotRegistered,
-    #[error("Invalid challenge")]
+    #[error("user already registered")]
+    AlreadyRegistered,
+    #[error("invalid challenge")]
     InvalidChallenge,
-    #[error("Invalid cookie")]
+    #[error("invalid cookie")]
     InvalidCookie,
-    #[error("User not authenticated")]
+    #[error("user not authenticated")]
     NotAuthenticated,
-    #[error("User already authenticated")]
+    #[error("user already authenticated")]
     AlreadyAuthenticated,
-    #[error("tokio_diesel async op failed with error: {:?}", _0)]
+    #[error("tokio_diesel async op failed with error: {}", _0)]
     TokioDieselAsync(#[from] tokio_diesel::AsyncError),
-    #[error("rust_sgx_util error: {:?}", _0)]
+    #[error("attesting quote failed with error: {}", _0)]
     RustSgxUtil(#[from] rust_sgx_util::Error),
-    #[error("r2d2 pool error {:?}", _0)]
+    #[error("r2d2 pool error: {}", _0)]
     R2d2Pool(#[from] diesel::r2d2::PoolError),
-    #[error("diesel result error {:?}", _0)]
+    #[error("diesel result error {}", _0)]
     DieselResult(#[from] diesel::result::Error),
-    #[error("var not found in env {:?}", _0)]
+    #[error("var not found in env: {}", _0)]
     Var(#[from] std::env::VarError),
     #[error("blocking operation was canceled prematurely")]
     ActixBlockingCanceled,
-    #[error("decoding base64 to blob: {:?}", _0)]
+    #[error("decoding base64 to blob: {}", _0)]
     Base64Decode(#[from] base64::DecodeError),
-    #[error("parsing ed25519 signature: {:?}", _0)]
+    #[error("parsing ed25519 signature: {}", _0)]
     Ed25519Signature(#[from] ed25519_dalek::SignatureError),
-    #[error("fetching entropy: {:?}", _0)]
+    #[error("fetching entropy: {}", _0)]
     GetRandom(#[from] getrandom::Error),
 }
 
 impl ResponseError for AppError {
     fn error_response(&self) -> HttpResponse {
-        let code = match self {
-            AppError::AlreadyRegistered => StatusCode::OK,
-            AppError::NotRegistered => StatusCode::FORBIDDEN,
-            AppError::InvalidChallenge => StatusCode::BAD_REQUEST,
-            AppError::InvalidCookie => StatusCode::BAD_REQUEST,
-            AppError::NotAuthenticated => StatusCode::FORBIDDEN,
-            AppError::AlreadyAuthenticated => StatusCode::OK,
-            AppError::TokioDieselAsync(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            // TODO map rust-sgx-util errors to status codes
-            AppError::RustSgxUtil(_) => StatusCode::BAD_REQUEST,
-            AppError::R2d2Pool(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            AppError::DieselResult(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            AppError::Var(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            AppError::ActixBlockingCanceled => StatusCode::INTERNAL_SERVER_ERROR,
-            AppError::Base64Decode(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            AppError::Ed25519Signature(_) => StatusCode::BAD_REQUEST,
-            AppError::GetRandom(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        let (code, message) = match self {
+            AppError::NotRegistered => (StatusCode::FORBIDDEN, Message::error()),
+            AppError::AlreadyRegistered => (StatusCode::OK, Message::ok()),
+            AppError::InvalidChallenge => (StatusCode::OK, Message::error()),
+            AppError::InvalidCookie => (StatusCode::OK, Message::error()),
+            AppError::NotAuthenticated => (StatusCode::FORBIDDEN, Message::error()),
+            AppError::AlreadyAuthenticated => (StatusCode::OK, Message::ok()),
+            AppError::TokioDieselAsync(_) => (StatusCode::INTERNAL_SERVER_ERROR, Message::error()),
+            AppError::RustSgxUtil(_) => (StatusCode::OK, Message::error()),
+            AppError::R2d2Pool(_) => (StatusCode::INTERNAL_SERVER_ERROR, Message::error()),
+            AppError::DieselResult(_) => (StatusCode::INTERNAL_SERVER_ERROR, Message::error()),
+            AppError::Var(_) => (StatusCode::INTERNAL_SERVER_ERROR, Message::error()),
+            AppError::ActixBlockingCanceled => {
+                (StatusCode::INTERNAL_SERVER_ERROR, Message::error())
+            }
+            AppError::Base64Decode(_) => (StatusCode::INTERNAL_SERVER_ERROR, Message::error()),
+            AppError::Ed25519Signature(_) => (StatusCode::OK, Message::error()),
+            AppError::GetRandom(_) => (StatusCode::INTERNAL_SERVER_ERROR, Message::error()),
         };
-        let body = format!("{}", self);
-        HttpResponseBuilder::new(code).json(json!({ "description": body }))
+        HttpResponseBuilder::new(code).json(message.add_param("description", format!("{}", self)))
     }
 }

--- a/pod-server/src/handlers/register.rs
+++ b/pod-server/src/handlers/register.rs
@@ -1,0 +1,79 @@
+use super::AppError;
+use crate::models::{NewUser, User};
+use crate::AppData;
+
+use diesel::prelude::*;
+
+use actix_web::error::BlockingError;
+use actix_web::{web, HttpResponse, Responder};
+use rust_sgx_util::{IasHandle, Nonce, Quote};
+use serde::Deserialize;
+use std::env;
+use tokio_diesel::{AsyncRunQueryDsl, OptionalExtension};
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterInfo {
+    login: String,
+    quote: Quote,
+    nonce: Option<Nonce>,
+}
+
+pub async fn post(info: web::Json<RegisterInfo>, app_data: web::Data<AppData>) -> impl Responder {
+    use crate::schema::users::dsl::*;
+
+    log::info!(
+        "Received register request for user with login '{}'.",
+        info.login
+    );
+    log::debug!("Received data: {:?}", info);
+
+    // Check if the user is already registered.
+    let result = users
+        .filter(login.eq(info.login.clone()))
+        .get_result_async::<User>(&app_data.pool)
+        .await
+        .optional()?;
+    log::debug!("Matching user records found: {:?}", result);
+
+    if let Some(_) = result {
+        log::info!("User already registered.");
+        return Err(AppError::AlreadyRegistered);
+    }
+
+    let quote = info.quote.clone();
+    let nonce = info.nonce.clone();
+    if let Err(err) = web::block(move || {
+        // Verify the provided data with IAS.
+        let api_key = env::var("POD_SERVER_API_KEY")?;
+        let handle = IasHandle::new(&api_key, None, None)?;
+        handle.verify_quote(&quote, nonce.as_ref(), None, None, None, None)?;
+        Ok(())
+    })
+    .await
+    {
+        match err {
+            BlockingError::Error(err) => return Err(err),
+            BlockingError::Canceled => return Err(AppError::ActixBlockingCanceled),
+        }
+    };
+
+    // Extract pub_key from Quote
+    // ED25519 public key is 32 bytes long
+    let report_data = info.quote.report_data()?;
+    let pub_key_ = base64::encode(&report_data[..32]);
+    log::debug!("Extracted public key (base64 encoded): {:?}", pub_key_);
+
+    // Insert user to the database.
+    let new_user = NewUser {
+        login: info.login.clone(),
+        pub_key: pub_key_,
+    };
+    diesel::insert_into(users)
+        .values(new_user)
+        .execute_async(&app_data.pool)
+        .await?;
+
+    log::info!("User '{}' successfully inserted into db.", info.login);
+
+    Ok(HttpResponse::Ok())
+}

--- a/pod-server/src/handlers/register.rs
+++ b/pod-server/src/handlers/register.rs
@@ -1,4 +1,4 @@
-use super::AppError;
+use super::{AppError, Message};
 use crate::models::{NewUser, User};
 use crate::AppData;
 
@@ -36,7 +36,7 @@ pub async fn post(info: web::Json<RegisterInfo>, app_data: web::Data<AppData>) -
     log::debug!("Matching user records found: {:?}", result);
 
     if let Some(_) = result {
-        log::info!("User already registered.");
+        log::info!("User '{}' already registered.", info.login);
         return Err(AppError::AlreadyRegistered);
     }
 
@@ -61,7 +61,7 @@ pub async fn post(info: web::Json<RegisterInfo>, app_data: web::Data<AppData>) -
     // ED25519 public key is 32 bytes long
     let report_data = info.quote.report_data()?;
     let pub_key_ = base64::encode(&report_data[..32]);
-    log::debug!("Extracted public key (base64 encoded): {:?}", pub_key_);
+    log::debug!("Extracted public key (base64 encoded): {}", pub_key_);
 
     // Insert user to the database.
     let new_user = NewUser {
@@ -74,6 +74,5 @@ pub async fn post(info: web::Json<RegisterInfo>, app_data: web::Data<AppData>) -
         .await?;
 
     log::info!("User '{}' successfully inserted into db.", info.login);
-
-    Ok(HttpResponse::Ok())
+    Ok(HttpResponse::Ok().json(Message::ok().add_param("description", "registration successful")))
 }

--- a/pod-server/src/main.rs
+++ b/pod-server/src/main.rs
@@ -32,6 +32,7 @@ struct Opt {
 struct ServerConfig {
     api_key: String,
     cookie_key: String,
+    #[serde(rename = "server")]
     bind: Option<BindAddress>,
 }
 

--- a/pod-server/src/main.rs
+++ b/pod-server/src/main.rs
@@ -1,5 +1,4 @@
-mod entrypoints;
-mod error;
+mod handlers;
 mod models;
 mod schema;
 
@@ -89,12 +88,12 @@ async fn main() -> anyhow::Result<()> {
             ))
             .wrap(middleware::Logger::default())
             .app_data(data.clone())
-            .route("/", web::get().to(entrypoints::index))
-            .route("/register", web::post().to(entrypoints::register))
+            .route("/", web::get().to(handlers::index))
+            .route("/register", web::post().to(handlers::register::post))
             .service(
                 web::resource("/auth")
-                    .route(web::get().to(entrypoints::get_auth))
-                    .route(web::post().to(entrypoints::auth)),
+                    .route(web::get().to(handlers::auth::get))
+                    .route(web::post().to(handlers::auth::post)),
             )
     })
     .bind(address_port)?


### PR DESCRIPTION
This PR cleans up the status code and body structure of returned http messages. It also fixed a bug with improper parsing of the `config.toml` file by the server.