### PR TITLE
Don't export public key to file

### DIFF
--- a/pod-client/pod_app/pod_app.c
+++ b/pod-client/pod_app/pod_app.c
@@ -9,7 +9,6 @@ struct option g_options[] = {
     { "help", no_argument, 0, 'h' },
     { "sealed-path", required_argument, 0, 's' },
     { "enclave-path", required_argument, 0, 'e' },
-    { "pubkey-path", required_argument, 0, 'p' },
     { "spid", required_argument, 0, 'i' },
     { "quote-type", required_argument, 0, 't' },
     { "quote-path", required_argument, 0, 'q' },
@@ -29,7 +28,6 @@ void usage(const char* exec) {
     printf("  --sealed-path, -s PATH   Path for sealed keys storage, default: " DEFAULT_SEALED_KEYS_PATH "\n");
     printf("  --enclave-path, -e PATH  Path for enclave binary, default: " DEFAULT_ENCLAVE_PATH "\n");
     printf("Available init options:\n");
-    printf("  --pubkey-path, -p PATH   Path to save enclave public key to, default: " DEFAULT_PUBLIC_KEY_PATH "\n");
     printf("  --spid, -i SPID          Service Provider ID received during IAS registration (hex string)\n");
     printf("  --quote-type, -t TYPE    Service Provider quote type, (l)inkable or (u)nlinkable)\n");
     printf("  --quote-path, -q PATH    Path to save enclave quote to, default: " DEFAULT_ENCLAVE_QUOTE_PATH "\n");
@@ -43,7 +41,6 @@ int main(int argc, char* argv[]) {
     char* sp_id = NULL;
     char* sp_quote_type = NULL;
     char* sealed_keys_path = DEFAULT_SEALED_KEYS_PATH;
-    char* public_key_path = DEFAULT_PUBLIC_KEY_PATH;
     char* enclave_path = DEFAULT_ENCLAVE_PATH;
     char* quote_path = DEFAULT_ENCLAVE_QUOTE_PATH;
     char* data_path = NULL;
@@ -66,9 +63,6 @@ int main(int argc, char* argv[]) {
                 break;
             case 'e':
                 enclave_path = optarg;
-                break;
-            case 'p':
-                public_key_path = optarg;
                 break;
             case 'i':
                 sp_id = optarg;
@@ -114,8 +108,7 @@ int main(int argc, char* argv[]) {
                 goto out;
             }
 
-            ret = pod_init_enclave(enclave_path, sp_id, sp_quote_type, sealed_keys_path,
-                                   public_key_path, quote_path);
+            ret = pod_init_enclave(enclave_path, sp_id, sp_quote_type, sealed_keys_path, quote_path);
             if (ret < 0)
                 goto out;
 

--- a/pod-client/pod_app/pod_app.h
+++ b/pod-client/pod_app/pod_app.h
@@ -7,9 +7,6 @@
 /** Default path to enclave binary. */
 #define DEFAULT_ENCLAVE_PATH "pod_enclave.signed.so"
 
-/** Default file name to save public key to. */
-#define DEFAULT_PUBLIC_KEY_PATH "pod_pubkey"
-
 /** Default file name to save enclave quote to. */
 #define DEFAULT_ENCLAVE_QUOTE_PATH "pod.quote"
 

--- a/pod-client/pod_library/pod_sgx.h
+++ b/pod-client/pod_library/pod_sgx.h
@@ -46,14 +46,12 @@ int write_file(const char* path, size_t size, const void* buffer);
  *  \param[in] sp_id_str           Service Provider ID (hex string).
  *  \param[in] sp_quote_type_str   Quote type as string ("linkable"/"unlinkable").
  *  \param[in] sealed_state_path   Path to sealed enclave state (will be overwritten).
- *  \param[in] enclave_pubkey_path Path where enclave public key will be saved.
  *  \param[in] quote_path          Path where enclave SGX quote will be saved.
  *
  *  \return 0 on success, negative on error.
  */
 int pod_init_enclave(const char* enclave_path, const char* sp_id_str, const char* sp_quote_type_str,
-                     const char* sealed_state_path, const char* enclave_pubkey_path,
-                     const char* quote_path);
+                     const char* sealed_state_path, const char* quote_path);
 
 /*!
  *  \brief Load PoD enclave and restore its private key from sealed state.

--- a/pod-server/examples/test_client.rs
+++ b/pod-server/examples/test_client.rs
@@ -5,7 +5,7 @@ use rust_sgx_util::{Nonce, Quote};
 use serde::Serialize;
 use std::ffi::CString;
 use std::path::Path;
-use std::{fs, io, ptr};
+use std::{fs, io};
 use structopt::StructOpt;
 
 #[link(name = "pod_sgx")]
@@ -15,7 +15,6 @@ extern "C" {
         sp_id_str: *const libc::c_char,
         sp_quote_type_str: *const libc::c_char,
         sealed_state_path: *const libc::c_char,
-        enclave_pubkey_path: *const libc::c_char,
         quote_path: *const libc::c_char,
     ) -> libc::c_int;
     fn pod_load_enclave(
@@ -74,7 +73,6 @@ fn init_enclave<P: AsRef<Path>>(
             spid.as_ptr(),
             quote_type.as_ptr(),
             sealed_state_path.as_ptr(),
-            ptr::null(),
             quote_path.as_ptr(),
         )
     };


### PR DESCRIPTION
Given that the public key is already embedded in the exported quote, I don't think we need to have separate functionality for exporting our public key to file upon enclave initialisation. This commit effectively removes this functionality in favour of dealing with the quote directly for public key extraction (which is already being done on the web server side anyhow BTW).

cc @mdtanrikulu @lukasz-glen Would love know your thoughts on this though guys, whether you reckon export public key to file is needed or not.