### PR TITLE
Save state and quote to the provided buffers rather than directly to files

### DIFF
--- a/pod-client/pod_app/pod_app.c
+++ b/pod-client/pod_app/pod_app.c
@@ -1,6 +1,7 @@
 #include <getopt.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #include "pod_app.h"
 #include "pod_sgx.h"
@@ -108,7 +109,14 @@ int main(int argc, char* argv[]) {
                 goto out;
             }
 
-            ret = pod_init_enclave(enclave_path, sp_id, sp_quote_type, sealed_keys_path, quote_path);
+            uint8_t quote[MAX_QUOTE_SIZE] = { 0 };
+            ret = pod_init_enclave(enclave_path, sp_id, sp_quote_type, sealed_keys_path, quote, MAX_QUOTE_SIZE);
+            if (ret < 0)
+                goto out;
+
+            // save quote to file
+            size_t quote_size = ret;
+            ret = write_file(quote_path, quote_size, quote);
             if (ret < 0)
                 goto out;
 

--- a/pod-client/pod_app/pod_app.c
+++ b/pod-client/pod_app/pod_app.c
@@ -109,8 +109,13 @@ int main(int argc, char* argv[]) {
                 goto out;
             }
 
+            ret = pod_init_enclave(enclave_path, sealed_keys_path);
+            if (ret < 0)
+                goto out;
+
+            // get quote
             uint8_t quote[MAX_QUOTE_SIZE] = { 0 };
-            ret = pod_init_enclave(enclave_path, sp_id, sp_quote_type, sealed_keys_path, quote, MAX_QUOTE_SIZE);
+            ret = pod_get_quote(enclave_path, sp_id, sp_quote_type, sealed_keys_path, quote, MAX_QUOTE_SIZE);
             if (ret < 0)
                 goto out;
 

--- a/pod-client/pod_app/pod_app.h
+++ b/pod-client/pod_app/pod_app.h
@@ -10,6 +10,9 @@
 /** Default file name to save enclave quote to. */
 #define DEFAULT_ENCLAVE_QUOTE_PATH "pod.quote"
 
+/** Maximum quote size. */
+#define MAX_QUOTE_SIZE 2048
+
 /** Enables enclave debugging and NULLIFIES ENCLAVE MEMORY PROTECTION. */
 #define ENCLAVE_DEBUG_ENABLED 1
 

--- a/pod-client/pod_app/pod_app.h
+++ b/pod-client/pod_app/pod_app.h
@@ -13,6 +13,9 @@
 /** Maximum quote size. */
 #define MAX_QUOTE_SIZE 2048
 
+/** Maximum sealed state size. */
+#define MAX_SEALED_STATE_SIZE 4096
+
 /** Enables enclave debugging and NULLIFIES ENCLAVE MEMORY PROTECTION. */
 #define ENCLAVE_DEBUG_ENABLED 1
 

--- a/pod-client/pod_library/pod_sgx.c
+++ b/pod-client/pod_library/pod_sgx.c
@@ -173,6 +173,7 @@ static int load_pod_enclave(const char* enclave_path, bool debug_enabled,
 out:
     if (!load_sealed_state)
         free(sealed_keys);
+
     return ret;
 }
 
@@ -186,7 +187,6 @@ static int generate_enclave_quote(sgx_spid_t sp_id, sgx_quote_sign_type_t quote_
     sgx_quote_nonce_t qe_nonce = { 0 };
     sgx_report_t qe_report = { 0 };
     uint32_t quote_size = 0;
-    sgx_quote_t* quote = (sgx_quote_t*) quote_buffer;
 
     if (g_enclave_id == 0) {
         fprintf(stderr, "Enclave not loaded\n");
@@ -239,7 +239,7 @@ static int generate_enclave_quote(sgx_spid_t sp_id, sgx_quote_sign_type_t quote_
                             NULL, // no revocation list
                             0, // revocation list size
                             &qe_report, // optional QE report
-                            quote,
+                            (sgx_quote_t*) quote_buffer,
                             quote_size);
 
     if (sgx_ret != SGX_SUCCESS) {
@@ -263,7 +263,7 @@ static int generate_enclave_quote(sgx_spid_t sp_id, sgx_quote_sign_type_t quote_
         goto out;
     }
 
-    if (SHA256_Update(&sha, quote, quote_size) != 1) {
+    if (SHA256_Update(&sha, (sgx_quote_t*) quote_buffer, quote_size) != 1) {
         fprintf(stderr, "Failed to calculate hash\n");
         goto out;
     }
@@ -294,7 +294,7 @@ int pod_init_enclave(const char* enclave_path, uint8_t* sealed_state, size_t sea
 int pod_load_enclave(const char* enclave_path, const uint8_t* sealed_state, size_t sealed_state_size) {
     return load_pod_enclave(enclave_path,
                             ENCLAVE_DEBUG_ENABLED,
-                            sealed_state,
+                            (uint8_t*) sealed_state,
                             sealed_state_size,
                             true); // load existing sealed state
 }

--- a/pod-client/pod_library/pod_sgx.c
+++ b/pod-client/pod_library/pod_sgx.c
@@ -281,19 +281,19 @@ out:
     return ret;
 }
 
-int pod_init_enclave(const char* enclave_path, const char* sp_id_str, const char* sp_quote_type_str,
-                     const char* sealed_state_path, uint8_t* quote_buffer, size_t quote_buffer_size) {
+int pod_init_enclave(const char* enclave_path, const char* sealed_state_path) {
+    return load_pod_enclave(enclave_path,
+                            ENCLAVE_DEBUG_ENABLED,
+                            sealed_state_path,
+                            false); // overwrite existing sealed state
+}
+
+int pod_get_quote(const char* sp_id_str, const char* sp_quote_type_str, uint8_t* quote_buffer,
+                  size_t quote_buffer_size) {
     sgx_spid_t sp_id = { 0 };
     sgx_quote_sign_type_t sp_quote_type;
+    int ret = -1;
 
-    int ret = load_pod_enclave(enclave_path,
-                               ENCLAVE_DEBUG_ENABLED,
-                               sealed_state_path,
-                               false); // overwrite existing sealed state
-    if (ret < 0)
-        goto out;
-
-    ret = -1;
     // parse SPID
     if (strlen(sp_id_str) != 32) {
         fprintf(stderr, "Invalid SPID: %s\n", sp_id_str);

--- a/pod-client/pod_library/pod_sgx.h
+++ b/pod-client/pod_library/pod_sgx.h
@@ -51,7 +51,7 @@ int write_file(const char* path, size_t size, const void* buffer);
  *  \return 0 on success, negative on error.
  */
 int pod_init_enclave(const char* enclave_path, const char* sp_id_str, const char* sp_quote_type_str,
-                     const char* sealed_state_path, const char* quote_path);
+                     const char* sealed_state_path, uint8_t* quote_buffer, size_t quote_buffer_size);
 
 /*!
  *  \brief Load PoD enclave and restore its private key from sealed state.

--- a/pod-client/pod_library/pod_sgx.h
+++ b/pod-client/pod_library/pod_sgx.h
@@ -39,21 +39,16 @@ int write_file(const char* path, size_t size, const void* buffer);
 
 /*!
  *  \brief Initialize PoD enclave.
- *         Loads enclave, generates new enclave key pair, seals the private key, exports quote
- *         and public key.
+ *         Loads enclave, generates new enclave key pair, and seals the private key into the provided
+ *         buffer.
  *
- *  \param[in] enclave_path        Path to enclave binary.
- *  \param[in] sp_id_str           Service Provider ID (hex string).
- *  \param[in] sp_quote_type_str   Quote type as string ("linkable"/"unlinkable").
- *  \param[in] sealed_state_path   Path to sealed enclave state (will be overwritten).
- *  \param[in] quote_path          Path where enclave SGX quote will be saved.
+ *  \param[in] enclave_path       Path to enclave binary.
+ *  \param[in] sealed_state       Buffer to seal the private key to.
+ *  \param[in] sealed_state_size  Size of the provided buffer.
  *
- *  \return 0 on success, negative on error.
+ *  \return On success, number of bytes written to the buffer. On failure, negative value.
  */
 int pod_init_enclave(const char* enclave_path, uint8_t* sealed_state, size_t sealed_state_size);
-
-int pod_get_quote(const char* sp_id_str, const char* sp_quote_type_str, uint8_t* quote_buffer,
-                  size_t quote_buffer_size);
 
 /*!
  *  \brief Load PoD enclave and restore its private key from sealed state.
@@ -71,6 +66,19 @@ int pod_load_enclave(const char* enclave_path, const uint8_t* sealed_state, size
  *  \return 0 on success, negative on error.
  */
 int pod_unload_enclave(void);
+
+/*!
+ *  \brief Generate valid quote of this PoD enclave for remote attestation with IAS services.
+ *
+ *  \param[in] sp_id_str          Service Provider ID (hex string).
+ *  \param[in] sp_quote_type_str  Quote type as string ("linkable"/"unlinkable").
+ *  \param[in] quote_buffer       Buffer to save the quote to.
+ *  \param[in] quote_buffer_size  Size of the provided buffer.
+ *
+ *  \return On success, number of bytes written to the buffer. On failure, negative value.
+ */
+int pod_get_quote(const char* sp_id_str, const char* sp_quote_type_str, uint8_t* quote_buffer,
+                  size_t quote_buffer_size);
 
 /*!
  *  \brief Create PoD enclave digital signature for data buffer.

--- a/pod-client/pod_library/pod_sgx.h
+++ b/pod-client/pod_library/pod_sgx.h
@@ -50,7 +50,7 @@ int write_file(const char* path, size_t size, const void* buffer);
  *
  *  \return 0 on success, negative on error.
  */
-int pod_init_enclave(const char* enclave_path, const char* sealed_state_path);
+int pod_init_enclave(const char* enclave_path, uint8_t* sealed_state, size_t sealed_state_size);
 
 int pod_get_quote(const char* sp_id_str, const char* sp_quote_type_str, uint8_t* quote_buffer,
                   size_t quote_buffer_size);
@@ -63,7 +63,7 @@ int pod_get_quote(const char* sp_id_str, const char* sp_quote_type_str, uint8_t*
  *
  *  \return 0 on success, negative on error.
  */
-int pod_load_enclave(const char* enclave_path, const char* sealed_state_path);
+int pod_load_enclave(const char* enclave_path, const uint8_t* sealed_state, size_t sealed_state_size);
 
 /*!
  *  \brief Unload PoD enclave.

--- a/pod-client/pod_library/pod_sgx.h
+++ b/pod-client/pod_library/pod_sgx.h
@@ -50,8 +50,10 @@ int write_file(const char* path, size_t size, const void* buffer);
  *
  *  \return 0 on success, negative on error.
  */
-int pod_init_enclave(const char* enclave_path, const char* sp_id_str, const char* sp_quote_type_str,
-                     const char* sealed_state_path, uint8_t* quote_buffer, size_t quote_buffer_size);
+int pod_init_enclave(const char* enclave_path, const char* sealed_state_path);
+
+int pod_get_quote(const char* sp_id_str, const char* sp_quote_type_str, uint8_t* quote_buffer,
+                  size_t quote_buffer_size);
 
 /*!
  *  \brief Load PoD enclave and restore its private key from sealed state.


### PR DESCRIPTION
**This PR builds on #12, so do not merge until that one is merged**

This PR tweaks `pod_library` in the following ways:
* It splits out quote generation from the enclave init call.
  When exporting both sealed keys _and_ quote to files, having init bundled with quote generation is nice to have. However, in our case, since we are more interested in receiving both the sealed state and quote as byte buffers, it makes more sense to unbundle init from quote generation. This commit does just that by modifying `pod_init_enclave` call, and introducing a new call `pod_get_quote`. The latter, much like `pod_sign_buffer`, assumes that the enclave has been loaded.
* Quote is now saved in to the provided byte buffer.
* Sealed state (or keys) are now also saved in to the provided byte buffer.
  This PR tweaks the `pod_library` to store the enclave's state in a provided byte buffer rather than save directly to file.

In general, `pod_library` communicating via byte buffers rather than files seems like a more optimal choice given that it's meant to be included in a Node extension module and become part of a browser extension. This way, we give the client the choice of what to do with the data: save it to a file, or dump it in browser's local storage.