### PR TITLE
Swap prints for log macros in c-api

### DIFF
--- a/crates/api/src/c.rs
+++ b/crates/api/src/c.rs
@@ -1,5 +1,6 @@
 #[link(name = "pod_sgx")]
 extern "C" {
+    pub(super) fn set_verbose(verbose: bool);
     pub(super) fn pod_init_enclave(
         enclave_path: *const libc::c_char,
         sealed_keys: *mut u8,

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -7,6 +7,8 @@ use std::cell::RefCell;
 use std::fs;
 use std::path::Path;
 
+pub use wrappers::set_verbose;
+
 pub enum QuoteType {
     Linkable,
     Unlinkable,

--- a/crates/api/src/wrappers.rs
+++ b/crates/api/src/wrappers.rs
@@ -9,6 +9,10 @@ const MAX_SEALED_KEYS_SIZE: usize = 1024; // Should be plenty for ed25519 privat
 const MAX_QUOTE_SIZE: usize = 2048; // Usually around 1200 bytes required
 const EC_SIGNATURE: usize = 64; // EC signature should always be 64bytes long!
 
+pub fn set_verbose(verbose: bool) {
+    unsafe { c::set_verbose(verbose) }
+}
+
 pub(super) fn init_enclave<P: AsRef<Path>>(enclave_path: P) -> Result<Vec<u8>> {
     let enclave_path = path_to_c_string(enclave_path)?;
     let sealed_keys_buffer = &mut [0u8; MAX_SEALED_KEYS_SIZE];

--- a/crates/c-api/pod-enclave/Makefile
+++ b/crates/c-api/pod-enclave/Makefile
@@ -45,7 +45,7 @@ CFLAGS += -m64 \
 	-std=c99 \
 	-I$(SGX_INC) \
 	-I$(SGX_INC)/tlibc \
-	-I$(SGX_SSL_INC)
+	-I$(SGX_SSL_INC) 
 
 LDFLAGS := -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles \
 	-L$(SGX_LIB) -L$(SGX_SSL_LIB) \

--- a/crates/c-api/pod-lib/Makefile
+++ b/crates/c-api/pod-lib/Makefile
@@ -23,7 +23,7 @@ CFLAGS += -fPIC \
     -m64 \
     -D_GNU_SOURCE \
     -I$(SGX_INC) \
-    -I../pod-enclave
+    -I../pod-enclave 
 
 LDFLAGS := -lcrypto \
     -L$(SGX_LIB) -lsgx_urts -lsgx_uae_service \
@@ -31,10 +31,13 @@ LDFLAGS := -lcrypto \
     -shared
 
 # Main binary
-$(LIBRARY_BIN): pod_sgx.o pod_enclave_u.o
+$(LIBRARY_BIN): pod_sgx.o pod_log.o pod_enclave_u.o
 	$(CC) $^ $(LDFLAGS) -o $@
 
 pod_sgx.o: pod_sgx.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+pod_log.o: pod_log.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 pod_enclave_u.o: ../pod-enclave/pod_enclave_u.c

--- a/crates/c-api/pod-lib/pod_log.c
+++ b/crates/c-api/pod-lib/pod_log.c
@@ -1,0 +1,13 @@
+#include "pod_log.h"
+
+int g_stdout_fd = 1;
+int g_stderr_fd = 2;
+bool g_verbose = false;
+
+void set_verbose(bool verbose) {
+  g_verbose = verbose;
+  if (verbose)
+    DBG("Verbose output enabled\n");
+  else
+    DBG("Verbose output disabled\n");
+}

--- a/crates/c-api/pod-lib/pod_log.h
+++ b/crates/c-api/pod-lib/pod_log.h
@@ -1,0 +1,18 @@
+#ifndef POD_LOG_H
+#define POD_LOG_H
+
+#include <stdio.h>
+#include <stdbool.h>
+
+// Source: https://github.com/oscarlab/graphene/blob/master/Pal/src/host/Linux-SGX/tools/common/util.h#L33
+extern int g_stdout_fd;
+extern int g_stderr_fd;
+extern bool g_verbose;
+
+#define DBG(fmt, ...)   do { if (g_verbose) dprintf(g_stdout_fd, fmt, ##__VA_ARGS__); } while (0)
+#define INFO(fmt, ...)  do { dprintf(g_stdout_fd, fmt, ##__VA_ARGS__); } while (0)
+#define ERROR(fmt, ...) do { dprintf(g_stderr_fd, "%s: " fmt, __FUNCTION__, ##__VA_ARGS__); } while (0)
+
+void set_verbose(bool verbose);
+
+#endif /* POD_LOG_H */

--- a/crates/server/examples/test_client.rs
+++ b/crates/server/examples/test_client.rs
@@ -53,6 +53,8 @@ struct ChallengeResponse {
 #[actix_rt::main]
 async fn main() -> anyhow::Result<()> {
     let opt = Opt::from_args();
+    // Turn on enclave logging
+    pod_api::set_verbose(true);
 
     let address = opt.address.unwrap_or_else(|| "127.0.0.1".to_owned());
     let port = opt.port.unwrap_or(8080);


### PR DESCRIPTION
This is needed for the `pod-app` if it's to be native messaging-compatible as we use `stdin` and `stdout` for comms.