### PR TITLE
Native messaging pod-app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+target/
+*.swp
+*.sealed
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,23 +8,13 @@ edition = "2018"
 pod-api = { path = "crates/api", version = "0.1.0" }
 rust-sgx-util = { path = "crates/rust-sgx-util", features = ["with_serde"], version = "0.2.3" }
 anyhow = "1"
+thiserror = "1"
 base64 = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 structopt = "0.3"
-log = "0.4"
-futures = "0.3"
-pretty_env_logger = "0.4"
-
-[dependencies.tokio]
-version = "0.2"
-features = [
-  "io-util",
-  "io-std",
-  "rt-core",
-  "macros",
-  "signal"
-]
+nix = "0.17"
+libc = "0.2"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,20 @@ anyhow = "1"
 base64 = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+structopt = "0.3"
+log = "0.4"
+futures = "0.3"
+pretty_env_logger = "0.4"
+
+[dependencies.tokio]
+version = "0.2"
+features = [
+  "io-util",
+  "io-std",
+  "rt-core",
+  "macros",
+  "signal"
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,87 @@
 # Proof-of-device
 
-Docs coming soon...
+Proof-of-device, or _pod_, is another take at 2FA or rather U2F. Here, however, the burden of storing
+keys for signing and proving your identity is managed by the SGX enclave. The service you're
+authenticating with sends you challenge which you sign using a private key embedded within the
+enclave in your Intel CPU. The system is very secure since not even you have the knowledge of
+the private key that's stored within the enclave.
+
+## Project structure
+
+The project comprises of four main components:
+* [`pod-enclave`] -- This is where the private key used for signing authentication challenge requests
+                     is generated and then stored. Note that the private key is actually stored on the
+                     host, however, in an enclave-sealed form which only the enclave that generated it
+                     can unseal to then use it for signing.
+* [`pod-app`] -- This is the native app that _pod_ uses to interface with the `pod-enclave`. It implements
+                 [native messaging] and therefore can be used from within a browser environment.
+* [`pod-browser`] -- This is the browser extension _pod_ uses as a GUI for the enduser of the _pod_
+                     authentication mechanism.
+* [`pod-server`] -- This is the web server that the service provider who offers _pod_ as an added authentication
+                    mechanism uses.
+
+[`pod-enclave`]: https://github.com/golemfactory/ProofOfDevice/tree/master/crates/c-api/pod-enclave
+[`pod-app`]: #pod-app
+[`pod-browser`]: https://github.com/golemfactory/ProofOfDevice
+[`pod-server`]: https://github.com/golemfactory/ProofOfDevice/tree/master/crates/server
+
+For each of the components, follow the links to learn more and check out how to build and run them.
+
+## `pod-app`
+
+The native app that _pod_ uses to interface with the `pod-enclave`. It implements [native messaging] and
+therefore can be used from within a browser environment such as [`pod-browser`].
+
+### Native messages handled by `pod-app`
+
+All requests are in JSON format. See [native messaging] for more info.
+
+* **Requests**:
+  - `{ "msg" : "get_quote",  "spid": "01234567abcdef" }`
+  - `{ "msg" : "sign_challenge", "challenge" : "AAADEADBEEF" }`
+
+* **Responses**
+  - `{ "msg" : "get_quote", "quote" : "AAAAA...AAA" }`
+  - `{ "msg" : "sign_challenge", "signed" : "BBBBBAAAAABB" }`
+  - `{ "msg" : "error", "description" : "description of the error" }`
+
+### Building
+
+Simply run from the repo's root:
+
+```
+cargo build
+```
+
+### Testing with `browser_mock` app
+
+For testing purposes, there is a `browser_mock` app as part of the `pod-app` which can be used for
+manual testing of the native messaging responses of the `pod-app`.
+
+To run it, first make sure `pod-app` is built:
+
+```
+cargo build
+```
+
+And then run:
+
+```
+cargo run --bin browser_mock target/debug/pod-app
+```
+
+You can send all request-type messages to the `pod-app` using `browser_mock` app and observe its
+response. For instance:
+
+```
+> { "msg": "sign_challenge", "challenge": "deadbeef" }
+{"msg":"sign_challenge","signed":"NYPXlzY98WUawum6yFQdelyzVoxC5VdguSSJ022ZJYyFc1W0DmZjnXP6t5t/gVwnckigP5u44yKmi7bIimiRBw=="}
+```
+
+[native messaging]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging#Closing_the_native_app
+
+## Caveats
+
+This project currently builds and was tested on Linux only (both Ubuntu 18.04 and Arch). In the future, it is envisaged
+to support Windows however.
+

--- a/src/bin/browser_mock.rs
+++ b/src/bin/browser_mock.rs
@@ -49,7 +49,6 @@ fn main() -> Result<()> {
             stdin.write_all(&msg_len.to_ne_bytes())?;
             stdin.write_all(json.as_bytes())?;
         }
-        println!("Message sent.");
 
         {
             let stdout = child

--- a/src/bin/mocker.rs
+++ b/src/bin/mocker.rs
@@ -1,0 +1,68 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::convert::TryFrom;
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Opt {
+    /// Path to native messaging enabled binary.
+    #[structopt(parse(from_os_str))]
+    path: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let opt = Opt::from_args();
+
+    loop {
+        print!("> ");
+        io::stdout().flush()?;
+
+        let mut json = String::new();
+        io::stdin().read_line(&mut json)?;
+        let json = json.trim();
+
+        if json.is_empty() {
+            continue;
+        }
+
+        if json == "exit" {
+            break;
+        }
+
+        let msg_len = json.len();
+        let msg_len = u32::try_from(msg_len)?;
+        let mut child = Command::new(&opt.path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()?;
+
+        {
+            let stdin = child
+                .stdin
+                .as_mut()
+                .ok_or(anyhow!("failed to open stdin"))?;
+            stdin.write_all(&msg_len.to_ne_bytes())?;
+            stdin.write_all(json.as_bytes())?;
+        }
+
+        {
+            let stdout = child.stdout.as_mut().ok_or(anyhow!("failed to open stdout"))?;
+            let mut msg_len = [0u8; 4];
+            stdout.read_exact(&mut msg_len)?;
+            let msg_len = u32::from_ne_bytes(msg_len);
+            let msg_len = usize::try_from(msg_len).expect("u32 should fit into usize");
+            println!("msg_len = {}", msg_len);
+
+            let mut msg = Vec::new();
+            msg.resize(120, 0);
+            stdout.read_exact(&mut msg)?;
+            let output: Value = serde_json::from_slice(&msg)?;
+            println!("{}", output);
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,28 @@
 use anyhow::Result;
+use futures::stream;
 use pod_api::{PodEnclave, QuoteType};
 use rust_sgx_util::Quote;
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
-use std::io::{self, Read, Write};
-use std::str;
+use std::convert::{TryFrom, TryInto};
+use std::{env, str};
+use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
+use tokio::signal;
 
 const SEALED_KEYS_PATH: &str = "pod_data.sealed";
-const ENCLAVE_PATH: &str = "../c-api/pod-enclave/pod_enclave.signed.so";
+const ENCLAVE_PATH: &str = "crates/c-api/pod-enclave/pod_enclave.signed.so";
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "msg", rename_all = "snake_case")]
-enum NativeMessage {
-    GetQuote,
-    Quote(Quote),
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", content = "message", rename_all = "snake_case")]
+enum IncomingMessage {
+    GetQuote(String),
     #[serde(with = "base_64")]
     Challenge(Vec<u8>),
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", content = "message", rename_all = "snake_case")]
+enum OutgoingMessage {
+    Quote(Quote),
     #[serde(with = "base_64")]
     Response(Vec<u8>),
 }
@@ -39,21 +46,56 @@ mod base_64 {
     }
 }
 
-fn main() -> Result<()> {
-    // let pod_enclave = PodEnclave::new(ENCLAVE_PATH, SEALED_KEYS_PATH)?;
-    loop {
-        // let mut msg_len = [0u8; 4];
-        // io::stdin().read_exact(&mut msg_len)?;
-        // let msg_len = u32::from_ne_bytes(msg_len);
-        // let msg_len = usize::try_from(msg_len).expect("u32 should fit into usize");
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Enable info logging by default.
+    env::set_var("RUST_LOG", "info");
+    pretty_env_logger::init();
+    pod_api::set_verbose(true);
 
-        let msg_len = 19;
-        let mut msg = Vec::new();
-        msg.resize(msg_len as usize, 0);
-        io::stdin().read_exact(&mut msg)?;
+    // TODO
+    // Ok, first pass will load and unload enclave at each message received
+    // event. However, this is definitely not optimal and we should spawn
+    // it only once and hand out Arc<> to the spawned instance instead.
+    // This will require some Mutexing though since PodEnclave is stateful
+    // (well, it's not itself, but the c-api that is uses underneath is).
 
-        let msg: NativeMessage = serde_json::from_slice(&msg)?;
-        println!("Received msg: {:?}", msg);
-    }
-    // TODO add signal handlers as we need to cleanup the enclave after it's been loaded!
+    let mut msg_len = [0u8; 4];
+    io::stdin().read_exact(&mut msg_len).await?;
+    let msg_len = u32::from_ne_bytes(msg_len);
+    let msg_len = usize::try_from(msg_len).expect("u32 should fit into usize");
+    log::info!("msg_len = {}", msg_len);
+
+    let mut msg = Vec::new();
+    msg.resize(msg_len as usize, 0);
+    io::stdin().read_exact(&mut msg).await?;
+
+    let msg: IncomingMessage = serde_json::from_slice(&msg)?;
+    log::info!("msg = {:?}", msg);
+
+    let reply = match msg {
+        IncomingMessage::GetQuote(spid) => {
+            let pod_enclave = PodEnclave::new(ENCLAVE_PATH, SEALED_KEYS_PATH)?;
+            let quote = pod_enclave.get_quote(spid, QuoteType::Unlinkable)?;
+            let reply = OutgoingMessage::Quote(quote);
+            log::info!("reply = {}", serde_json::to_string(&reply)?);
+            let serialized = serde_json::to_vec(&reply)?;
+            serialized
+        }
+        IncomingMessage::Challenge(challenge) => {
+            let pod_enclave = PodEnclave::new(ENCLAVE_PATH, SEALED_KEYS_PATH)?;
+            let signature = pod_enclave.sign(challenge)?;
+            let reply = OutgoingMessage::Response(signature);
+            log::info!("reply = {}", serde_json::to_string(&reply)?);
+            let serialized = serde_json::to_vec(&reply)?;
+            log::info!("reply = {:?}", serde_json::to_vec(&reply)?);
+            serialized
+        }
+    };
+    let reply_len: u32 = reply.len().try_into()?;
+    log::info!("reply_len = {}", reply_len);
+    io::stdout().write_all(&reply_len.to_ne_bytes()).await?;
+    io::stdout().write_all(&reply).await?;
+
+    Ok(())
 }


### PR DESCRIPTION
Uses tokio with async io for stdin and stdout since we need to be
able to react to kill signals. Adds a mocking app for testing the
functionality of `pod-app`.