### PR TITLE
Add logging to file in pod-app

### DIFF
--- a/pod-app/Cargo.lock
+++ b/pod-app/Cargo.lock
@@ -106,15 +106,16 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20066d9200ef8d441ac156c76dd36c3f1e9a15976c34e69ae97f7f570b331882"
+checksum = "143fcc2912e0d1de2bcf4e2f720d2a60c28652ab4179685a1ee159e0fb3db227"
 dependencies = [
  "actix-macros",
  "actix-threadpool",
  "copyless",
  "futures-channel",
  "futures-util",
+ "smallvec",
  "tokio",
 ]
 
@@ -295,6 +296,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+
+[[package]]
 name = "async-trait"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +399,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "blake2b_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "brotli-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "copyless"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +519,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +538,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+dependencies = [
+ "cfg-if",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_users",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -729,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15"
+checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "libc",
 ]
@@ -795,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa79fa216fbe60834a9c0737d7fcd30425b32d1c58854663e24d4c4b328ed83f"
+checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
 dependencies = [
  "socket2",
  "widestring",
@@ -1081,11 +1144,13 @@ dependencies = [
  "base64 0.12.0",
  "cc",
  "libc",
+ "log",
  "nix",
  "pod-api",
  "rust-sgx-util",
  "serde",
  "serde_json",
+ "simplelog",
  "structopt",
  "thiserror",
  "xdg",
@@ -1207,6 +1272,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
+name = "redox_users"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1308,18 @@ checksum = "11834e137f3b14e309437a8276714eed3a80d1ef894869e510f2c0c0b98b9f4a"
 dependencies = [
  "hostname",
  "quick-error",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
+dependencies = [
+ "base64 0.11.0",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1284,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 dependencies = [
  "itoa",
  "ryu",
@@ -1319,6 +1407,17 @@ checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 dependencies = [
  "arc-swap",
  "libc",
+]
+
+[[package]]
+name = "simplelog"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf9a002ccce717d066b3ccdb8a28829436249867229291e91b25d99bd723f0d"
+dependencies = [
+ "chrono",
+ "log",
+ "term",
 ]
 
 [[package]]
@@ -1377,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1410,6 +1509,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
+dependencies = [
+ "dirs",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,18 +1529,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
+checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
+checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1468,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9c43f1bb96970e153bcbae39a65e249ccb942bd9d36dbdf086024920417c9c"
+checksum = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
 dependencies = [
  "bytes",
  "fnv",

--- a/pod-app/Cargo.toml
+++ b/pod-app/Cargo.toml
@@ -16,6 +16,8 @@ structopt = "0.3"
 nix = "0.17"
 libc = "0.2"
 xdg = "2"
+log = "0.4"
+simplelog = "0.7"
 
 [dev-dependencies]
 actix-web = "2"

--- a/pod-app/src/main.rs
+++ b/pod-app/src/main.rs
@@ -1,14 +1,15 @@
 mod messages;
 
 use anyhow::{anyhow, Context, Result};
-use messages::{reply, OutgoingMessage};
+use messages::reply;
 use nix::sys::signal::{self, SigHandler, Signal};
 use serde::Deserialize;
 use std::convert::{TryFrom, TryInto};
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
-use std::process;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::{fs, process};
 
 const DEFAULT_PRIVATE_KEY_PATH: &str = "private_key.sealed";
 const DEFAULT_ENCLAVE_PATH: &str = "../pod-enclave/pod_enclave.signed.so";
@@ -27,25 +28,66 @@ extern "C" fn handle_signals(signal: libc::c_int) {
 struct Config {
     private_key: PathBuf,
     enclave: PathBuf,
+    log_output: PathBuf,
 }
 
 impl Default for Config {
     fn default() -> Self {
         let enclave = PathBuf::from(DEFAULT_ENCLAVE_PATH);
         let private_key = PathBuf::from(DEFAULT_PRIVATE_KEY_PATH);
+        let log_output = PathBuf::from(log_filename());
         Self {
             enclave,
             private_key,
+            log_output,
         }
     }
 }
 
-fn run() -> Result<()> {
-    let config = config()?;
+enum Interrupt {
+    Break,
+    Continue,
+}
+
+enum Stdio {
+    Stdin,
+    Stdout,
+}
+
+fn stdio_with_interrupt(handle: Stdio, buffer: &mut [u8]) -> Result<Interrupt> {
+    let res = match handle {
+        Stdio::Stdin => io::stdin().read_exact(buffer),
+        Stdio::Stdout => io::stdout().write_all(buffer),
+    };
+    match res {
+        Ok(_) => Ok(Interrupt::Continue),
+        Err(err) => {
+            match err.kind() {
+                io::ErrorKind::BrokenPipe | io::ErrorKind::UnexpectedEof => {
+                    // Unless we received a SIGTERM and the other closed the pipe
+                    // on purpose, we need to throw an error!
+                    if !SIGNALED.load(Ordering::Relaxed) {
+                        Err(anyhow!("Unexpected EOF or a broken pipe!"))
+                    } else {
+                        log::debug!("Received termination signal, exiting...");
+                        Ok(Interrupt::Break)
+                    }
+                }
+                _ => Err(anyhow!(
+                    "failed to read message len from stdin (first 4 bytes): {}",
+                    err
+                )),
+            }
+        }
+    }
+}
+
+fn run(config: Config) -> Result<()> {
     // Install signal handler for SIGINT and SIGTERM
     let handler = SigHandler::Handler(handle_signals);
     unsafe { signal::signal(Signal::SIGTERM, handler)? };
     unsafe { signal::signal(Signal::SIGINT, handler)? };
+    log::debug!("Registered SIGTERM and SIGINT signal handlers");
     // Ok, first pass will load and unload enclave at each message received
     // event. However, this is definitely not optimal and we should spawn
     // it only once and hand out Arc<> to the spawned instance instead.
@@ -53,79 +95,114 @@ fn run() -> Result<()> {
     // across thread boundaries.
     loop {
         if SIGNALED.load(Ordering::Relaxed) {
+            log::debug!("Received termination signal, exiting...");
             break;
         }
 
         let mut msg_len = [0u8; 4];
-
-        if let Err(err) = io::stdin().read_exact(&mut msg_len) {
-            match err.kind() {
-                io::ErrorKind::BrokenPipe | io::ErrorKind::UnexpectedEof => {
-                    // Unless we received a SIGTERM and the other closed the pipe
-                    // on purpose, we need to throw an error!
-                    if !SIGNALED.load(Ordering::Relaxed) {
-                        return Err(anyhow!("Unexpected EOF or a broken pipe!"));
-                    }
-                }
-                _ => {
-                    return Err(anyhow!(
-                        "failed to read message len from stdin (first 4 bytes): {}",
-                        err
-                    ))
-                }
-            }
-        }
-
+        match stdio_with_interrupt(Stdio::Stdin, &mut msg_len) {
+            Err(err) => return Err(err),
+            Ok(Interrupt::Break) => break,
+            Ok(Interrupt::Continue) => {},
+        };
         let msg_len = u32::from_ne_bytes(msg_len);
         let msg_len = usize::try_from(msg_len).expect("u32 should fit into usize");
 
+        if msg_len == 0 {
+            if SIGNALED.load(Ordering::Relaxed) {
+                log::debug!("Received termination signal, exiting...");
+                break;
+            }
+
+            // TODO is this correct behaviour? Should we actually simply carry on listening?
+            continue;
+        }
+
+        log::debug!("Received message len (first 4 bytes): {}", msg_len);
+
         let mut msg = Vec::new();
         msg.resize(msg_len as usize, 0);
-        io::stdin()
-            .read_exact(&mut msg)
-            .context("failed to read message from stdin")?;
-
-        let reply = match reply(msg, &config) {
-            Ok(reply) => reply,
-            Err(err) => serde_json::to_vec(&OutgoingMessage::error(err))
-                .context("converting error to JSON failed")?,
+        match stdio_with_interrupt(Stdio::Stdin, &mut msg) {
+            Err(err) => return Err(err),
+            Ok(Interrupt::Break) => break,
+            Ok(Interrupt::Continue) => {},
         };
+
+        log::debug!("Message received");
+
+        let mut reply = reply(msg, &config)?;
         let reply_len: u32 = reply
             .len()
             .try_into()
             .context("reply len overflew 32bit register")?;
-        io::stdout()
-            .write_all(&reply_len.to_ne_bytes())
-            .context("failed to write reply length to stdout (first 4 bytes)")?;
-        io::stdout()
-            .write_all(&reply)
-            .context("failed to write reply to stdout")?;
+        match stdio_with_interrupt(Stdio::Stdout, &mut reply_len.to_ne_bytes()) {
+            Err(err) => return Err(err),
+            Ok(Interrupt::Break) => break,
+            Ok(Interrupt::Continue) => {},
+        };
+
+        log::debug!("Sent reply len: {}", reply_len);
+
+        match stdio_with_interrupt(Stdio::Stdout, &mut reply) {
+            Err(err) => return Err(err),
+            Ok(Interrupt::Break) => break,
+            Ok(Interrupt::Continue) => {},
+        };
         io::stdout().flush()?;
+
+        log::debug!("Reply sent");
     }
 
     Ok(())
 }
 
-fn config() -> Result<Config> {
+fn config() -> Config {
     // Firstly, check in xdg config folder.
     let dirs = xdg::BaseDirectories::with_prefix("pod-app")
-        .context("couldn't create xdg base dir instance")?;
-    let config = match dirs.find_data_file("pod_enclave.signed.so") {
+        .expect("couldn't create xdg base dir instance");
+
+    match dirs.find_data_file("pod_enclave.signed.so") {
         Some(enclave) => {
-            let private_key = dirs.get_data_home().join("private_key.sealed");
+            let data_home = dirs.get_data_home();
+            let private_key = data_home.join("private_key.sealed");
+            let log_output = data_home.join(log_filename());
+
             Config {
                 private_key,
                 enclave,
+                log_output,
             }
         }
         None => Config::default(),
-    };
-    Ok(config)
+    }
+}
+
+fn log_filename() -> String {
+    // TODO add some stronger uniqueness to log names
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("could get current system time");
+    format!("pod-app_{}.log", now.as_secs_f64())
 }
 
 fn main() {
-    if let Err(err) = run() {
-        eprintln!("Unexpected error occurred: {}", err);
+    let config = config();
+    let log_output =
+        fs::File::create(&config.log_output).expect("could initialize file for logger output");
+
+    simplelog::WriteLogger::init(
+        log::LevelFilter::Debug,
+        simplelog::Config::default(),
+        log_output,
+    )
+    .expect("could initialize logger");
+
+    log::debug!("Application started...");
+
+    if let Err(err) = run(config) {
+        log::error!("Unexpected error occurred: {}", err);
         process::exit(1);
     }
+
+    log::debug!("Application successfully stopped...");
 }

--- a/pod-app/src/messages.rs
+++ b/pod-app/src/messages.rs
@@ -28,9 +28,6 @@ pub(super) enum OutgoingMessage {
         #[serde(with = "base_64")]
         signed: Vec<u8>,
     },
-    Error {
-        description: String,
-    },
 }
 
 impl OutgoingMessage {
@@ -41,12 +38,6 @@ impl OutgoingMessage {
     pub fn sign_challenge<B: AsRef<[u8]>>(signed: B) -> Self {
         Self::SignChallenge {
             signed: signed.as_ref().to_vec(),
-        }
-    }
-
-    pub fn error<S: ToString>(desc: S) -> Self {
-        Self::Error {
-            description: desc.to_string(),
         }
     }
 }
@@ -72,6 +63,8 @@ mod base_64 {
 
 pub(super) fn reply<B: AsRef<[u8]>>(msg: B, config: &Config) -> Result<Vec<u8>> {
     let msg: IncomingMessage = serde_json::from_slice(msg.as_ref())?;
+    log::debug!("Received message content: {:?}", msg);
+
     let reply = match msg {
         IncomingMessage::GetQuote { spid } => {
             let pod_enclave = PodEnclave::new(&config.enclave, &config.private_key)?;
@@ -88,5 +81,7 @@ pub(super) fn reply<B: AsRef<[u8]>>(msg: B, config: &Config) -> Result<Vec<u8>> 
             serialized
         }
     };
+
+    log::debug!("Reply content: {:?}", reply);
     Ok(reply)
 }


### PR DESCRIPTION
Logging `pod-app` is somewhat awkward since we use `stdin` and `stdout`
as comms channels to speak with the browser extension. For debugging
however it would good to have some info about what is going on
in the app. This commit enables logging to a file of the internals
of `pod-app`.